### PR TITLE
fix insert-date for inactive/naked dates

### DIFF
--- a/org-review.el
+++ b/org-review.el
@@ -194,9 +194,10 @@ specified by FMT."
    propname
    (cond
     ((eq fmt 'inactive)
-     (concat "[" (substring date 1 -1) "]"))
-    ((eq fmt 'active) date)
-    (t (substring date 1 -1)))))
+     (concat "[" date "]"))
+    ((eq fmt 'active)
+     (concat "<" date ">"))
+    (t date))))
 
 ;;;###autoload
 (defun org-review-insert-last-review (&optional prompt)


### PR DESCRIPTION
after 466f7d, org-review-insert-date consistently gets a naked datestamp without "<>" brackets. therefore, it should no longer try to strip those brackets using (substring).